### PR TITLE
used jellyfish icon; edited color of PJ text

### DIFF
--- a/JellyFish.html
+++ b/JellyFish.html
@@ -41,7 +41,7 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         </button>
-                        <a class="navbar-brand" href="#"><i class="fa fa-rocket"></i> Project Jellyfish</a>
+                        <a class="navbar-brand" href="#"><img src="ico/favicon.ico" alt="jellyfish" height="26" style="width:10%"> Project Jellyfish</a>
                     </div>
                     <div class="collapse navbar-collapse">
                         <ul class="nav navbar-nav navbar-right">

--- a/css/style.css
+++ b/css/style.css
@@ -219,7 +219,7 @@ p, ul { color: rgba(34,42,49,.7); }
 /* ! Nav
 /* ======================================================================== */
 .navbar .navbar-brand {
-	color: #222a31;
+	color: #F88954 ;
 	padding: 24px 15px 0;
 	font-size: 30px;
 }


### PR DESCRIPTION
- Eventually we'll want to use the font icon that Chris K made to replace this favicon.ico
- We should look carefully at the orange used in the Jellyfish. It appears to not match perfectly with the #F88954 (orange) of the Jellyfish color palette, as seen in the logo wording "Project Jellyfish". 
