### PR TITLE
using the dark orange from the panels to match the jf

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -219,7 +219,7 @@ p, ul { color: rgba(34,42,49,.7); }
 /* ! Nav
 /* ======================================================================== */
 .navbar .navbar-brand {
-	color: #F88954 ;
+	color: #e2614d;
 	padding: 24px 15px 0;
 	font-size: 30px;
 }


### PR DESCRIPTION
Even though the darker orange (#e2614d) is not technically the Jellyfish orange from our JF palette, I couldn't stand to see them mismatched. 
